### PR TITLE
fix(pvc): pvc should be deployed to the proper namespace

### DIFF
--- a/clusters/apps/base/soho/nextcloud/pvc.yaml
+++ b/clusters/apps/base/soho/nextcloud/pvc.yaml
@@ -9,7 +9,7 @@ spec:
   accessModes:
     - ReadWriteMany
   claimRef:
-    namespace: nextcloud
+    namespace: soho
     name: nextcloud-data
   storageClassName: pandora
   nfs:
@@ -39,7 +39,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   claimRef:
-    namespace: nextcloud
+    namespace: soho
     name: nextcloud-db
   storageClassName: pandora
   nfs:


### PR DESCRIPTION
pvcs for nextcloud were applying to an old namespace and therefore not creating properly

#16