### PR TITLE
refactor(storage): storage should be created outside of helm releases

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,61 @@
+#
+# Ansible related variables
+#
+
+# The network interface on the host kube-vip should attach to
+# e.g. eno1
+export BOOTSTRAP_ANSIBLE_KUBE_VIP_INTERFACE="eth0"
+# IP Address to use with KubeVIP
+# Pick a unused IP that is on the same network as your nodes
+# e.g. 192.168.1.254
+export BOOTSTRAP_ANSIBLE_KUBE_VIP_ADDRESS="192.168.130.30"
+
+#
+# Ansible hosts - repeat this block as many times as you need,
+# incrementing the last digit on the variable name for each node
+#
+### k-master01 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_0="192.168.130.31"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_0="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_0=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_0="true"
+### k-master02 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_1="192.168.130.32"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_1="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_1=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_1="true"
+### k-master03 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_2="192.168.130.33"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_2="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_2=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_2="true"
+### k-node01 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_3="192.168.130.41"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_3="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_3=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_3="false"
+### k-node02 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_4="192.168.130.42"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_4="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_4=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_4="false"
+### k-node03 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_5="192.168.130.43"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_5="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_5=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_5="false"
+### k-node1 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_6="192.168.130.51"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_6="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_6=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_6="false"
+### k-node2 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_7="192.168.130.52"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_7="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_7=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_7="false"
+### k-node3 ###
+export BOOTSTRAP_ANSIBLE_HOST_ADDR_8="192.168.130.53"
+export BOOTSTRAP_ANSIBLE_SSH_USERNAME_8="ubuntu"
+export BOOTSTRAP_ANSIBLE_SUDO_PASSWORD_8=""
+export BOOTSTRAP_ANSIBLE_CONTROL_NODE_8="false"

--- a/.gitignore
+++ b/.gitignore
@@ -16,15 +16,12 @@
 auth
 master.key
 *.snap
-setup/cluster/*cluster.yml
 *.rkestate
 kubeconfig
 gitignore/
-# temporary
-setup/.env
 
 # Ansible
-ansible/playbooks/output/k8s-config.yaml
+ansible/*
 
 # Vim
 *.swp

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+python-gilt = "*"
+ansible = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,289 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "5cd39064423241c75caa7ed3ad04770a7c25cf61ad84e3b40cbc4295f135619b"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "ansible": {
+            "hashes": [
+                "sha256:2955fcbf51367f8bd88c38a86f8be83d4fcd05f778afb4feed31abfe8dcff639"
+            ],
+            "index": "pypi",
+            "version": "==4.6.0"
+        },
+        "ansible-core": {
+            "hashes": [
+                "sha256:7d3ce47014122907454704363485e48513f8ad0f00138b88870eb6d88953d121"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.11.5"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:06c54a68935738d206570b20da5ef2b6b6d92b38ef3ec45c5422c0ebaf338d4d",
+                "sha256:0c0591bee64e438883b0c92a7bed78f6290d40bf02e54c5bf0978eaf36061771",
+                "sha256:19ca0dbdeda3b2615421d54bef8985f72af6e0c47082a8d26122adac81a95872",
+                "sha256:22b9c3c320171c108e903d61a3723b51e37aaa8c81255b5e7ce102775bd01e2c",
+                "sha256:26bb2549b72708c833f5abe62b756176022a7b9a7f689b571e74c8478ead51dc",
+                "sha256:33791e8a2dc2953f28b8d8d300dde42dd929ac28f974c4b4c6272cb2955cb762",
+                "sha256:3c8d896becff2fa653dc4438b54a5a25a971d1f4110b32bd3068db3722c80202",
+                "sha256:4373612d59c404baeb7cbd788a18b2b2a8331abcc84c3ba40051fcd18b17a4d5",
+                "sha256:487d63e1454627c8e47dd230025780e91869cfba4c753a74fda196a1f6ad6548",
+                "sha256:48916e459c54c4a70e52745639f1db524542140433599e13911b2f329834276a",
+                "sha256:4922cd707b25e623b902c86188aca466d3620892db76c0bdd7b99a3d5e61d35f",
+                "sha256:55af55e32ae468e9946f741a5d51f9896da6b9bf0bbdd326843fec05c730eb20",
+                "sha256:57e555a9feb4a8460415f1aac331a2dc833b1115284f7ded7278b54afc5bd218",
+                "sha256:5d4b68e216fc65e9fe4f524c177b54964af043dde734807586cf5435af84045c",
+                "sha256:64fda793737bc4037521d4899be780534b9aea552eb673b9833b01f945904c2e",
+                "sha256:6d6169cb3c6c2ad50db5b868db6491a790300ade1ed5d1da29289d73bbe40b56",
+                "sha256:7bcac9a2b4fdbed2c16fa5681356d7121ecabf041f18d97ed5b8e0dd38a80224",
+                "sha256:80b06212075346b5546b0417b9f2bf467fea3bfe7352f781ffc05a8ab24ba14a",
+                "sha256:818014c754cd3dba7229c0f5884396264d51ffb87ec86e927ef0be140bfdb0d2",
+                "sha256:8eb687582ed7cd8c4bdbff3df6c0da443eb89c3c72e6e5dcdd9c81729712791a",
+                "sha256:99f27fefe34c37ba9875f224a8f36e31d744d8083e00f520f133cab79ad5e819",
+                "sha256:9f3e33c28cd39d1b655ed1ba7247133b6f7fc16fa16887b120c0c670e35ce346",
+                "sha256:a8661b2ce9694ca01c529bfa204dbb144b275a31685a075ce123f12331be790b",
+                "sha256:a9da7010cec5a12193d1af9872a00888f396aba3dc79186604a09ea3ee7c029e",
+                "sha256:aedb15f0a5a5949ecb129a82b72b19df97bbbca024081ed2ef88bd5c0a610534",
+                "sha256:b315d709717a99f4b27b59b021e6207c64620790ca3e0bde636a6c7f14618abb",
+                "sha256:ba6f2b3f452e150945d58f4badd92310449876c4c954836cfb1803bdd7b422f0",
+                "sha256:c33d18eb6e6bc36f09d793c0dc58b0211fccc6ae5149b808da4a62660678b156",
+                "sha256:c9a875ce9d7fe32887784274dd533c57909b7b1dcadcc128a2ac21331a9765dd",
+                "sha256:c9e005e9bd57bc987764c32a1bee4364c44fdc11a3cc20a40b93b444984f2b87",
+                "sha256:d2ad4d668a5c0645d281dcd17aff2be3212bc109b33814bbb15c4939f44181cc",
+                "sha256:d950695ae4381ecd856bcaf2b1e866720e4ab9a1498cba61c602e56630ca7195",
+                "sha256:e22dcb48709fc51a7b58a927391b23ab37eb3737a98ac4338e2448bef8559b33",
+                "sha256:e8c6a99be100371dbb046880e7a282152aa5d6127ae01783e37662ef73850d8f",
+                "sha256:e9dc245e3ac69c92ee4c167fbdd7428ec1956d4e754223124991ef29eb57a09d",
+                "sha256:eb687a11f0a7a1839719edd80f41e459cc5366857ecbed383ff376c4e3cc6afd",
+                "sha256:eb9e2a346c5238a30a746893f23a9535e700f8192a68c07c0258e7ece6ff3728",
+                "sha256:ed38b924ce794e505647f7c331b22a693bee1538fdf46b0222c4717b42f744e7",
+                "sha256:f0010c6f9d1a4011e429109fda55a225921e3206e7f62a0c22a35344bfd13cca",
+                "sha256:f0c5d1acbfca6ebdd6b1e3eded8d261affb6ddcf2186205518f1428b8569bb99",
+                "sha256:f10afb1004f102c7868ebfe91c28f4a712227fe4cb24974350ace1f90e1febbf",
+                "sha256:f174135f5609428cc6e1b9090f9268f5c8935fddb1b25ccb8255a2d50de6789e",
+                "sha256:f3ebe6e73c319340830a9b2825d32eb6d8475c1dac020b4f0aa774ee3b898d1c",
+                "sha256:f627688813d0a4140153ff532537fbe4afea5a3dffce1f9deb7f91f848a832b5",
+                "sha256:fd4305f86f53dfd8cd3522269ed7fc34856a8ee3709a5e28b2836b2db9d4cd69"
+            ],
+            "version": "==1.14.6"
+        },
+        "click": {
+            "hashes": [
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.4.4"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:0a7dcbcd3f1913f664aca35d47c1331fce738d44ec34b7be8b9d332151b0b01e",
+                "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b",
+                "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7",
+                "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085",
+                "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc",
+                "sha256:3c4129fc3fdc0fa8e40861b5ac0c673315b3c902bbdc05fc176764815b43dd1d",
+                "sha256:3fa3a7ccf96e826affdf1a0a9432be74dc73423125c8f96a909e3835a5ef194a",
+                "sha256:5b0fbfae7ff7febdb74b574055c7466da334a5371f253732d7e2e7525d570498",
+                "sha256:695104a9223a7239d155d7627ad912953b540929ef97ae0c34c7b8bf30857e89",
+                "sha256:8695456444f277af73a4877db9fc979849cd3ee74c198d04fc0776ebc3db52b9",
+                "sha256:94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c",
+                "sha256:94fff993ee9bc1b2440d3b7243d488c6a3d9724cc2b09cdb297f6a886d040ef7",
+                "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb",
+                "sha256:a00cf305f07b26c351d8d4e1af84ad7501eca8a342dedf24a7acb0e7b7406e14",
+                "sha256:a305600e7a6b7b855cd798e00278161b681ad6e9b7eca94c721d5f588ab212af",
+                "sha256:cd65b60cfe004790c795cc35f272e41a3df4631e2fb6b35aa7ac6ef2859d554e",
+                "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5",
+                "sha256:d9ec0e67a14f9d1d48dd87a2531009a9b251c02ea42851c060b25c782516ff06",
+                "sha256:f44d141b8c4ea5eb4dbc9b3ad992d45580c1d22bf5e24363f2fbf50c2d7ae8a7"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.8"
+        },
+        "fasteners": {
+            "hashes": [
+                "sha256:8408e52656455977053871990bd25824d85803b9417aa348f10ba29ef0c751f7",
+                "sha256:b1ab4e5adfbc28681ce44b3024421c4f567e705cc3963c732bf1cba3348307de"
+            ],
+            "version": "==0.16.3"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
+                "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.1"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
+                "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
+                "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38",
+                "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
+                "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
+                "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
+                "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
+                "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.20"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.4.7"
+        },
+        "python-gilt": {
+            "hashes": [
+                "sha256:e220ea2e7e190ee06dbfa5fafe87967858b4ac0cf53f3072fa6ece4664a42082"
+            ],
+            "index": "pypi",
+            "version": "==1.2.3"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
+        },
+        "resolvelib": {
+            "hashes": [
+                "sha256:8113ae3ed6d33c6be0bcbf03ffeb06c0995c099b7b8aaa5ddf2e9b3b3df4e915",
+                "sha256:9b9b80d5c60e4c2a8b7fbf0712c3449dc01d74e215632e5199850c9eca687628"
+            ],
+            "version": "==0.5.4"
+        },
+        "sh": {
+            "hashes": [
+                "sha256:4921ac9c1a77ec8084bdfaf152fe14138e2b3557cc740002c1a97076321fce8a",
+                "sha256:9d7bd0334d494b2a4609fe521b2107438cdb21c0e469ffeeb191489883d6fe0d"
+            ],
+            "version": "==1.14.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.16.0"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -15,23 +15,30 @@
 
 # :book:&nbsp; Overview
 
-Welcome to my home Kubernetes cluster. This repo _is_ my Kubernetes cluster in a declarative state. [Flux](https://github.com/fluxcd/flux2) and [Helm Operator](https://github.com/fluxcd/helm-operator) watch my [clusters](./clusters/) folder and makes the changes to my cluster based on the yaml manifests.
+This repo _is_ my Kubernetes cluster in a declarative state. [Flux](https://github.com/fluxcd/flux2) and [Helm Operator](https://github.com/fluxcd/helm-operator) watch my [clusters](./clusters/) folder and makes the changes to my cluster based on the yaml manifests. [Renovate](https://github.com/renovatebot/renovate) auto updates images and helm charts based on upstream changes.
 
-Feel free to join our [Discord](https://discord.gg/DNCynrJ) if you have any questions.
+Feel free to join our [Discord](https://discord.gg/k8s-at-home) if you have any questions.
 
 ---
 
 # :anchor:&nbsp; k8s Distro
 
-Currently using [k0s](https://k0sproject.io/) by way of a customized [k0s-ansible](https://github.com/movd/k0s-ansible).
+Currently using [k3s](https://k3s.io) by way of a customized [template-cluster-k3s](https://github.com/k8s-at-home/template-cluster-k3s) [ansible playbook](https://github.com/k8s-at-home/template-cluster-k3s/tree/main/provision/ansible).
 
 ---
-# :speedboat:&nbsp; Deploying
+# :speedboat:&nbsp; Deploying k3s
+
+1. `pip install pipenv`
+2. `pipenv install`
+3. `pipenv run gilt overlay`
+4. `pipenv run ansible-playbook -i ansible/inventory/inventory.yaml ansible/playbooks/k3s-install.yaml`
+5. `scp root@192.168.130.31:/etc/rancher/k3s/k3s.yaml ~/.kube/config`
+6. `sops -d sops-secret.enc.yaml | kubectl apply -f -`
 
 1. Have a working `kubeconfig`
 2. Have `flux` installed
-
-To boostrap the cluster:
+3. Have `GITHUB_TOKEN` env var set to a Github PAT
+4. To boostrap the cluster:
 
         flux bootstrap github \
         --components=source-controller,kustomize-controller,helm-controller,notification-controller \
@@ -39,6 +46,8 @@ To boostrap the cluster:
         --version=latest \
         --owner=crutonjohn \
         --repository=gitops
+
+5. `sops -d sops-secret.enc.yaml | kubectl apply -f -`
 
 ---
 ## :computer:&nbsp; Hardware Configuration
@@ -48,7 +57,8 @@ _All my nodes below are running bare metal Ubuntu 20.04.x_
 | Device                  | Count | OS Disk Size            | Data Disk Size                           | Ram  | Purpose |
 |-------------------------|-------|-------------------------|------------------------------------------|------|---------|
 | Raspberry Pi 4          | 3     | 120GB (USB Booting SSD) | N/A                                      | 4 GB | k8s Control Plane |
-| Dell R610               | 3     | 2x 120GB SSD (RAID1)    | 2x 1TB HDD (RAID0, longhorn)             | 40GB | k8s Workers |
+| Dell R610 (decom soon)  | 3     | 2x 120GB SSD (RAID1)    | 2x 1TB HDD (RAID0, longhorn)             | 40GB | k8s Workers |
+| Dell 7040 Micro         | 3     | 1x 500B HDD             | 1x 1TB M.2 SSD (longhorn)                | 32GB | k8s Workers |
 
 ## :computer:&nbsp; Supporting Infrastructure
 
@@ -84,16 +94,6 @@ _This table is a reference to IP addresses in my deployments and may not be full
 | vernemq                  | 192.168.130.109 |
 
 ---
+## :handshake:&nbsp; Community
 
-## :handshake:&nbsp; Thanks
-
-A lot of inspiration for this repo came from the following people:
-
-- [billimek/k8s-gitops](https://github.com/billimek/k8s-gitops)
-- [carpenike/k8s-gitops](https://github.com/carpenike/k8s-gitops)
-- [dcplaya/k8s-gitops](https://github.com/dcplaya/k8s-gitops)
-- [rust84/k8s-gitops](https://github.com/rust84/k8s-gitops)
-- [blackjid/homelab-gitops](https://github.com/blackjid/homelab-gitops)
-- [bjw-s/k8s-gitops](https://github.com/bjw-s/k8s-gitops)
-- [nlopez/k8s_home](https://github.com/nlopez/k8s_home)
-- [onedr0p/home-cluster](https://github.com/onedr0p/home-cluster)
+Thanks to all the people who donate their time to the [Kubernetes @Home](https://github.com/k8s-at-home/) community. Join us at https://discord.gg/k8s-at-home

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,58 @@
+[defaults]
+
+#--- General settings
+nocows                      = True
+forks                       = 8
+module_name                 = command
+deprecation_warnings        = True
+executable                  = /bin/bash
+stdout_callback             = yaml
+
+#--- Files/Directory settings
+log_path                = ~/ansible.log
+inventory               = ./ansible/inventory
+library                 = /usr/share/my_modules
+remote_tmp              = /tmp/.ansible/tmp
+local_tmp               = /tmp/.ansible/tmp
+roles_path              = ./ansible/roles
+retry_files_enabled     = False
+
+#--- Fact Caching settings
+fact_caching            = jsonfile
+fact_caching_connection = ~/.ansible/facts_cache
+fact_caching_timeout    = 7200
+
+#--- SSH settings
+remote_port             = 22
+timeout                 = 60
+host_key_checking       = False
+ssh_executable          = /usr/bin/ssh
+private_key_file        = ~/.ssh/id_rsa
+
+force_valid_group_names = ignore
+
+#--- Speed
+callback_enabled       = true
+internal_poll_interval = 0.001
+
+#--- Plugin settings
+vars_plugins_enabled = host_group_vars,community.sops.sops
+
+[inventory]
+unparsed_is_failed      = true
+
+[privilege_escalation]
+become                  = True
+become_method           = sudo
+become_user             = root
+become_ask_pass         = False
+
+[ssh_connection]
+scp_if_ssh              = smart
+transfer_method         = smart
+retries                 = 3
+timeout                 = 10
+ssh_args                = -o ControlMaster=auto -o ControlPersist=30m -o Compression=yes -o ServerAliveInterval=15s
+pipelining              = True
+control_path            = %(directory)s/%%h-%%r
+

--- a/clusters/apps/base/games/minecraft/hr.yaml
+++ b/clusters/apps/base/games/minecraft/hr.yaml
@@ -123,5 +123,4 @@ spec:
       dataDir:
         # Set this to false if you don't care to persist state between restarts.
         enabled: true
-        # existingClaim: nil
-        Size: 20Gi
+        existingClaim: homecraft-data

--- a/clusters/apps/base/games/minecraft/kustomization.yaml
+++ b/clusters/apps/base/games/minecraft/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - hr.yaml
+  - pvc.yaml

--- a/clusters/apps/base/games/minecraft/pvc.yaml
+++ b/clusters/apps/base/games/minecraft/pvc.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homecraft-data
+  namespace: games
+spec:
+  accessModes:
+    - ReadWriteOnce

--- a/clusters/apps/base/media/pvc.yaml
+++ b/clusters/apps/base/media/pvc.yaml
@@ -4,17 +4,8 @@ kind: PersistentVolume
 metadata:
   name: music-library
 spec:
-  capacity:
-    storage: 1024Gi
   accessModes:
     - ReadWriteMany
-  claimRef:
-    namespace: media
-    name: music-library
-  storageClassName: pandora
-  nfs:
-    server: 192.168.130.50
-    path: "/pandora/music-library/"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -24,7 +15,3 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: pandora
-  resources:
-    requests:
-      storage: 1024Gi

--- a/clusters/apps/base/network-system/blocky/hr.yaml
+++ b/clusters/apps/base/network-system/blocky/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: blocky
       version: 8.0.0
       sourceRef:

--- a/clusters/apps/base/network-system/cert-manager/hr.yaml
+++ b/clusters/apps/base/network-system/cert-manager/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://charts.jetstack.io/
       chart: cert-manager
       version: v1.5.3
       sourceRef:

--- a/clusters/apps/base/network-system/librespeed/hr.yaml
+++ b/clusters/apps/base/network-system/librespeed/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: librespeed
       version: 5.0.0
       sourceRef:
@@ -24,10 +25,10 @@ spec:
           external-dns/public: "true"
         ingressClassName: "external"
         hosts:
-          - host: speedof.crutonjohn.com
+          - host: speedof.${SECRET_DOMAIN}
             paths:
               - path: /
                 pathType: ImplementationSpecific
         tls:
           - hosts:
-              - speedof.crutonjohn.com
+              - speedof.${SECRET_DOMAIN}

--- a/clusters/apps/base/network-system/metallb/hr.yaml
+++ b/clusters/apps/base/network-system/metallb/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://metallb.github.io/metallb
       chart: metallb
       version: 0.10.2
       sourceRef:

--- a/clusters/apps/base/network-system/nginx-ingress/external/hr.yaml
+++ b/clusters/apps/base/network-system/nginx-ingress/external/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://kubernetes.github.io/ingress-nginx
       chart: ingress-nginx
       version: 3.36.0
       sourceRef:

--- a/clusters/apps/base/network-system/nginx-ingress/internal/hr.yaml
+++ b/clusters/apps/base/network-system/nginx-ingress/internal/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://kubernetes.github.io/ingress-nginx
       chart: ingress-nginx
       version: 3.36.0
       sourceRef:

--- a/clusters/apps/base/network-system/unifi-poller/hr.yaml
+++ b/clusters/apps/base/network-system/unifi-poller/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: unifi-poller
       version: 5.2.1
       sourceRef:

--- a/clusters/apps/base/network-system/unifi/hr.yaml
+++ b/clusters/apps/base/network-system/unifi/hr.yaml
@@ -8,8 +8,9 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: unifi
-      version: 2.0.2
+      version: 4.2.2
       sourceRef:
         kind: HelmRepository
         name: k8s-at-home-charts
@@ -17,43 +18,38 @@ spec:
   values:
     image:
       repository: jacobalberty/unifi
-      tag: 5.12.35
+      tag: 5.14.23
     persistence:
-      enabled: true
-      size: 5Gi
-      storageClass: longhorn
-    timezone: "America/New_York"
-    runAsRoot: false
-    guiService:
-      type: LoadBalancer
-      loadBalancerIP: 192.168.130.103
-      annotations:
-        metallb.universe.tf/allow-shared-ip: unifi
-    controllerService:
-      type: LoadBalancer
-      loadBalancerIP: 192.168.130.103
-      annotations:
-        metallb.universe.tf/allow-shared-ip: unifi
-    stunService:
-      type: LoadBalancer
-      loadBalancerIP: 192.168.130.103
-      annotations:
-        metallb.universe.tf/allow-shared-ip: unifi
-    discoveryService:
-      type: LoadBalancer
-      loadBalancerIP: 192.168.130.103
-      annotations:
-        metallb.universe.tf/allow-shared-ip: unifi
+      data:
+        enabled: true
+        mountPath: /unifi
+        existingClaim: unifi-config
+    env:
+      TZ: "America/New_York"
+    service:
+      main:
+        type: LoadBalancer
+        annotations:
+          metallb.universe.tf/allow-shared-ip: unifi
+        loadBalancerIP: ${CLUSTER_LB_UNIFI}
+        externalTrafficPolicy: Local
     resources:
       requests:
-        memory: 500Mi
-        cpu: 15m
+        memory: 1024M
+        cpu: 30m
       limits:
-        memory: 750Mi
+        memory: 1536M
     ingress:
-      enabled: true
-      annotations:
-        kubernetes.io/ingress.class: "internal"
-        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-      hosts:
-        - unifi.crutonjohn.com
+      main:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: "internal"
+          nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+        hosts:
+          - host: unifi.${SECRET_DOMAIN}
+            paths:
+              - path: /
+                pathType: ImplementationSpecific
+        tls:
+          - hosts:
+              - unifi.${SECRET_DOMAIN}

--- a/clusters/apps/base/network-system/unifi/kustomization.yaml
+++ b/clusters/apps/base/network-system/unifi/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- hr.yaml
-# - vs.yaml
+  - hr.yaml
+  # - vs.yaml
+  - pvc.yaml

--- a/clusters/apps/base/network-system/unifi/pvc.yaml
+++ b/clusters/apps/base/network-system/unifi/pvc.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: unifi-config
+  namespace: network-system
+spec:
+  accessModes:
+    - ReadWriteOnce

--- a/clusters/apps/base/observability/botkube/hr.yaml
+++ b/clusters/apps/base/observability/botkube/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://infracloudio.github.io/charts
       chart: botkube
       version: v0.12.1
       sourceRef:

--- a/clusters/apps/base/observability/grafana/hr.yaml
+++ b/clusters/apps/base/observability/grafana/hr.yaml
@@ -9,6 +9,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://grafana.github.io/helm-charts
       chart: grafana
       version: 6.16.00
       sourceRef:

--- a/clusters/apps/base/observability/loki/hr.yaml
+++ b/clusters/apps/base/observability/loki/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://grafana.github.io/loki/charts
       chart: loki-stack
       version: 2.3.1
       sourceRef:

--- a/clusters/apps/base/soho/baremetalblog/hr.yaml
+++ b/clusters/apps/base/soho/baremetalblog/hr.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://crutonjohn.github.io/helm-charts/
       chart: baremetalblog
       version: 0.1.1
       sourceRef:
@@ -15,13 +16,17 @@ spec:
         name: crutonjohn-charts
         namespace: flux-system
   values:
-    istio:
+    ingress:
       enabled: true
-      baremetalblog:
-        enabled: true
-        annotations: {}
-        labels: {}
-        gateways:
-          - istio-system/main
-        hosts:
-          - baremetalblog.com
+      annotations:
+        kubernetes.io/ingress.class: external
+        external-dns/public: "true"
+        external-dns.alpha.kubernetes.io/target: ${DYNAMIC_DOMAIN}
+      hosts:
+        - host: "baremetalblog.com"
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - "baremetalblog.com"

--- a/clusters/apps/base/soho/bitwarden/kustomization.yaml
+++ b/clusters/apps/base/soho/bitwarden/kustomization.yaml
@@ -3,4 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - hr.yaml
-  # - vs.yaml
+  - pvc.yaml

--- a/clusters/apps/base/soho/bitwarden/pvc.yaml
+++ b/clusters/apps/base/soho/bitwarden/pvc.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bitwarden-config
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce

--- a/clusters/apps/base/soho/frigate/hr.yaml
+++ b/clusters/apps/base/soho/frigate/hr.yaml
@@ -209,9 +209,8 @@ spec:
     persistence:
       data:
         enabled: true
-        accessMode: ReadWriteOnce
-        size: 20Gi
         mountPath: /data
+        existingClaim: frigate-data
       media:
         enabled: true
         mountPath: /media

--- a/clusters/apps/base/soho/hassio/hr.yaml
+++ b/clusters/apps/base/soho/hassio/hr.yaml
@@ -76,10 +76,9 @@ spec:
     persistence:
       config:
         enabled: true
-        storageClass: "longhorn"
-        accessMode: ReadWriteOnce
-        size: 25Gi
-        ## Do not delete the pvc upon helm uninstall
+        mountPath: /data
+        existingClaim: home-assistant-config
+        accessMode: ReadWriteMany
         skipuninstall: false
     addons:
       codeserver:

--- a/clusters/apps/base/soho/hassio/kustomization.yaml
+++ b/clusters/apps/base/soho/hassio/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - hr.yaml
   - code.enc.yaml
   - hass.enc.yaml
+  - pvc.yaml

--- a/clusters/apps/base/soho/hassio/pvc.yaml
+++ b/clusters/apps/base/soho/hassio/pvc.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: home-assistant-config
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteMany

--- a/clusters/apps/base/soho/nextcloud/kustomization.yaml
+++ b/clusters/apps/base/soho/nextcloud/kustomization.yaml
@@ -2,6 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - pvc.yaml
   - hr.yaml
+  - pvc.yaml
   # - vs.yaml

--- a/clusters/apps/base/soho/paperless/kustomization.yaml
+++ b/clusters/apps/base/soho/paperless/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - hr.yaml
+  - pvc.yaml

--- a/clusters/apps/base/soho/paperless/pvc.yaml
+++ b/clusters/apps/base/soho/paperless/pvc.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-data
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-export
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-media
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-consume
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce

--- a/clusters/apps/base/soho/zigbee2mqtt/hr.yaml
+++ b/clusters/apps/base/soho/zigbee2mqtt/hr.yaml
@@ -76,12 +76,9 @@ spec:
     persistence:
       config:
         enabled: true
-        storageClass: "longhorn"
         accessMode: ReadWriteOnce
-        size: 1Gi
-        ## Do not delete the pvc upon helm uninstall
-        skipuninstall: false
         mountPath: "/data"
+        existingClaim: zigbee2mqtt-config
       usb:
         enabled: true
         type: hostPath

--- a/clusters/apps/base/soho/zigbee2mqtt/kustomization.yaml
+++ b/clusters/apps/base/soho/zigbee2mqtt/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - hr.yaml
+  - pvc.yaml

--- a/clusters/apps/base/soho/zigbee2mqtt/pvc.yaml
+++ b/clusters/apps/base/soho/zigbee2mqtt/pvc.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zigbee2mqtt-config
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteMany

--- a/clusters/apps/env/production/kustomization.yaml
+++ b/clusters/apps/env/production/kustomization.yaml
@@ -16,3 +16,13 @@ resources:
   - wildcard-cert.yaml
 patchesStrategicMerge:
   - patch.metallb.yaml
+  # - patch.pvc.yaml
+  - ./storage-patches/bitwarden.yaml
+  - ./storage-patches/frigate.yaml
+  - ./storage-patches/hassio.yaml
+  - ./storage-patches/minecraft.yaml
+  - ./storage-patches/music.yaml
+  - ./storage-patches/nextcloud.yaml
+  - ./storage-patches/paperless.yaml
+  - ./storage-patches/unifi.yaml
+  - ./storage-patches/zigbee2mqtt.yaml

--- a/clusters/apps/env/production/storage-patches/bitwarden.yaml
+++ b/clusters/apps/env/production/storage-patches/bitwarden.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bitwarden-config
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: longhorn

--- a/clusters/apps/env/production/storage-patches/frigate.yaml
+++ b/clusters/apps/env/production/storage-patches/frigate.yaml
@@ -7,14 +7,27 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: longhorn
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: frigate-data-pandora
 spec:
+  capacity:
+    storage: 8192Gi
   accessModes:
     - ReadWriteMany
+  claimRef:
+    namespace: soho
+    name: frigate-data-pandora
+  storageClassName: pandora
+  nfs:
+    server: 192.168.130.50
+    path: "/pandora/k8/frigate-data/"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -24,3 +37,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: pandora
+  resources:
+    requests:
+      storage: 8192Gi

--- a/clusters/apps/env/production/storage-patches/hassio.yaml
+++ b/clusters/apps/env/production/storage-patches/hassio.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: home-assistant-config
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 25Gi
+  storageClassName: longhorn

--- a/clusters/apps/env/production/storage-patches/minecraft.yaml
+++ b/clusters/apps/env/production/storage-patches/minecraft.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homecraft-data
+  namespace: games
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: longhorn

--- a/clusters/apps/env/production/storage-patches/music.yaml
+++ b/clusters/apps/env/production/storage-patches/music.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: music-library
+spec:
+  capacity:
+    storage: 1024Gi
+  accessModes:
+    - ReadWriteMany
+  claimRef:
+    namespace: media
+    name: music-library
+  storageClassName: pandora
+  nfs:
+    server: 192.168.130.50
+    path: "/pandora/music-library/"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: music-library
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: pandora
+  resources:
+    requests:
+      storage: 1024Gi

--- a/clusters/apps/env/production/storage-patches/nextcloud.yaml
+++ b/clusters/apps/env/production/storage-patches/nextcloud.yaml
@@ -4,8 +4,17 @@ kind: PersistentVolume
 metadata:
   name: nextcloud-data
 spec:
+  capacity:
+    storage: 1024Gi
   accessModes:
     - ReadWriteMany
+  claimRef:
+    namespace: soho
+    name: nextcloud-data
+  storageClassName: pandora
+  nfs:
+    server: 192.168.130.50
+    path: "/pandora/k8/nextcloud-data/"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -15,6 +24,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: pandora
+  resources:
+    requests:
+      storage: 1024Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -24,3 +37,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/clusters/apps/env/production/storage-patches/paperless.yaml
+++ b/clusters/apps/env/production/storage-patches/paperless.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-data
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: longhorn
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-export
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-media
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: longhorn
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-consume
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/clusters/apps/env/production/storage-patches/unifi.yaml
+++ b/clusters/apps/env/production/storage-patches/unifi.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: unifi-config
+  namespace: network-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/clusters/apps/env/production/storage-patches/zigbee2mqtt.yaml
+++ b/clusters/apps/env/production/storage-patches/zigbee2mqtt.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zigbee2mqtt-config
+  namespace: soho
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn

--- a/gilt.yml
+++ b/gilt.yml
@@ -1,0 +1,10 @@
+---
+- git: https://github.com/k8s-at-home/template-cluster-k3s.git
+  version: main
+  files:
+    - src: "provision/ansible"
+      dst: ansible/
+      post_commands:
+        - ansible-galaxy install -r requirements.yml --force
+        - cp ../vars/inventory.yaml inventory/inventory.yaml
+        - cp ../vars/kube-vip.yaml inventory/group_vars/kubernetes/kube-vip.yaml

--- a/vars/inventory.yaml
+++ b/vars/inventory.yaml
@@ -1,0 +1,29 @@
+---
+kubernetes:
+  children:
+    master:
+      hosts:
+        k-master01:
+          ansible_host: 192.168.130.31
+        k-master02:
+          ansible_host: 192.168.130.32
+        k-master03:
+          ansible_host: 192.168.130.33
+      vars:
+        ansible_user: ubuntu
+    worker:
+      hosts:
+        k-node01:
+          ansible_host: 192.168.130.41
+        k-node02:
+          ansible_host: 192.168.130.42
+        k-node03:
+          ansible_host: 192.168.130.43
+        k-node1:
+          ansible_host: 192.168.130.51
+        k-node2:
+          ansible_host: 192.168.130.52
+        k-node3:
+          ansible_host: 192.168.130.53
+      vars:
+        ansible_user: root

--- a/vars/kube-vip.yaml
+++ b/vars/kube-vip.yaml
@@ -1,0 +1,5 @@
+---
+# (string) The interface on the host kube-vip should attach to
+kubevip_interface: "eth0"
+# (string) The ARP address kube-vip broadcasts
+kubevip_address: "192.168.130.30"


### PR DESCRIPTION
storage resources created inside helm releases cause issues when upgrading said helm releases.
creating these PVCs outside of the helm release cycle will allow charts to upgrade without the need
for creating the storage itself, thereby avoiding inevitable helm release failures upon running an
upgrade.

BREAKING CHANGE: backing storage mechanism reworked; should likely only be merged after hardware
cutover in #61

#61