### PR TITLE
Decrease Mating/Breeding Timers

### DIFF
--- a/clusters/apps/env/production/games/ark/app/hr.yaml
+++ b/clusters/apps/env/production/games/ark/app/hr.yaml
@@ -190,9 +190,10 @@ spec:
             WildDinoCharacterFoodDrainMultiplier=1.500000
             NPCReplacements=(FromClassName="Ichthyornis_Character_BP_C",ToClassName="")
             NPCReplacements=(FromClassName="Pegomastax_Character_BP_C",ToClassName="")
-            MatingIntervalMultiplier=0.100000
-            EggHatchSpeedMultiplier=2.000000
-            BabyMatureSpeedMultiplier=4.000000
+            MatingIntervalMultiplier=0.010000
+            MatingSpeedMultiplier=2.000000
+            EggHatchSpeedMultiplier=4.000000
+            BabyMatureSpeedMultiplier=8.000000
             BabyFoodConsumptionSpeedMultiplier=0.500000
           GameUserSettingsIni: |
             # The Island User Settings ini


### PR DESCRIPTION
Mating Interval 0.1 -> 0.01 (~15 mins for a rex)
Egg Hatch Speed 2.0 -> 4.0 (~1 hr 15 mins for a rex egg)
Baby Mature Speed 4.0 -> 8.0 (2x faster)

Added:
MatingSpeedMultiplier (makes the mating progress bar twice as fast).